### PR TITLE
Do not raise DeprecationWarning on using non-deprecated methods

### DIFF
--- a/src/marisa_trie.pyx
+++ b/src/marisa_trie.pyx
@@ -210,12 +210,12 @@ cdef class _Trie:
     def save(self, path):
         """Save a trie to a specified path."""
         with open(path, 'w') as f:
-            self.write(f)
+            self._trie.write(f.fileno())
 
     def load(self, path):
         """Load a trie from a specified path."""
         with open(path, 'r') as f:
-            self.read(f)
+            self._trie.read(f.fileno())
         return self
 
     cpdef bytes tobytes(self) except +:


### PR DESCRIPTION
Currently ``save()`` and ``load()`` methods raise ``DeprecationWarning`` because they use deprecated ``write()`` and ``read()`` methods internally, this is mentioned in #36. In this patch I moved contents of latter methods to former to avoid warnings.