### PR TITLE
Potential fix for Mac OS Mojave

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,8 @@ CLASSIFIERS = [
     "Topic :: Text Processing :: Linguistic",
 ]
 
+extra_compile_args = ["-stdlib=libstdc++"]
+
 setup(name="marisa-trie",
       version="0.7.5",
       description=DESCRIPTION,
@@ -54,10 +56,6 @@ setup(name="marisa-trie",
       license=LICENSE,
       url="https://github.com/kmike/marisa-trie",
       classifiers=CLASSIFIERS,
-      libraries=[("libmarisa-trie", {
-          "sources": MARISA_FILES,
-          "include_dirs": [MARISA_SOURCE_DIR, MARISA_INCLUDE_DIR]
-      })],
       ext_modules=[
           Extension("marisa_trie", [
               "src/agent.cpp",
@@ -69,7 +67,9 @@ setup(name="marisa-trie",
               "src/query.cpp",
               "src/std_iostream.cpp",
               "src/trie.cpp"
-          ], include_dirs=[MARISA_INCLUDE_DIR])
+          ] + MARISA_FILES, include_dirs=[MARISA_INCLUDE_DIR, MARISA_SOURCE_DIR],
+            extra_compile_args=extra_compile_args
+          )
       ],
 
       python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',


### PR DESCRIPTION
Dear maintainers,
Running into some install issues with wrong headers or missing symbols.
Current solution has been to create a single compilation unit and using env-specific C++ stdlib flags during compilation.

Do you have any better suggestions for working around this? I imagine compiling marisa as part of the extension might not be ideal if you intended to skip reinstalling marisa for users who installed it separately (1), and the compiler flags should be changed on an system by system basis (2).

(1) I could not find a way to specific compiler flags for the `setup(..., libraries=[(lib, {...<flags go here ?> }])` part of the setup code. I suspect if this is possible, this should now work as intended on mojave.

(2) Detecting mac os v other systems should not be too hard. Given that issues so far have only sprung up on mac os, I am not sure we need anything fancier than "if macOS: add flag else: pass"

