### PR TITLE
Fix ResourceWarning: unclosed file in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,8 @@ MARISA_FILES[:] = itertools.chain(
       for path in MARISA_FILES))
 
 DESCRIPTION = __doc__
-LONG_DESCRIPTION = open("README.rst").read() + open("CHANGES.rst").read()
+with open("README.rst") as f1, open("CHANGES.rst") as f2:
+    LONG_DESCRIPTION = f1.read() + f2.read()
 LICENSE = "MIT"
 
 CLASSIFIERS = [


### PR DESCRIPTION
```
setup.py:26: ResourceWarning: unclosed file <_io.TextIOWrapper name='README.rst' mode='r' encoding='UTF-8'>
  LONG_DESCRIPTION = open("README.rst").read() + open("CHANGES.rst").read()
ResourceWarning: Enable tracemalloc to get the object allocation traceback
setup.py:26: ResourceWarning: unclosed file <_io.TextIOWrapper name='CHANGES.rst' mode='r' encoding='UTF-8'>
  LONG_DESCRIPTION = open("README.rst").read() + open("CHANGES.rst").read()
ResourceWarning: Enable tracemalloc to get the object allocation traceback
```