### PR TITLE
Include docstrings in cython code

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,10 @@ MARISA_FILES[:] = itertools.chain(
     *(glob.glob(os.path.join(MARISA_SOURCE_DIR, path)) for path in MARISA_FILES)
 )
 
+COMPILER_DIRECTIVES = {
+    'embedsignature': True,
+}
+
 DESCRIPTION = __doc__
 # TODO: Switch back to builtin `open(FILE, encoding="utf-8")` when dropping Python 2.7 support
 with open("README.rst", encoding="utf-8") as f1, open(
@@ -98,6 +102,7 @@ setup(
                 "src/trie.cpp",
             ],
             include_dirs=[MARISA_INCLUDE_DIR],
+            compiler_directives=COMPILER_DIRECTIVES,
         )
     ],
     python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*",


### PR DESCRIPTION
This fixes the API doc generation. Currently API docs is not generated: https://marisa-trie.readthedocs.io/en/latest/api.html. 

This "should" fix it. It is the right flag, but I'm not certain Extension accept that arg there. But, if the CI doesn't choke on the new kwarg, then it should work.