### PR TITLE
Build and publish aarch64 wheels

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -26,6 +26,13 @@ jobs:
         with:
           ref: ${{ github.event.inputs.branch }}
           submodules: true
+
+      - name: Set up QEMU
+        if: runner.os == 'Linux'
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: all
+
       - name: Install Python
         uses: actions/setup-python@v5
         with:
@@ -37,10 +44,16 @@ jobs:
         env:
           CIBW_SKIP: "cp36-*" # skip 3.6
           CIBW_ARCHS_MACOS: "x86_64 universal2 arm64"
+          CIBW_ARCHS_LINUX: "auto aarch64"
       - uses: actions/upload-artifact@v4
         with:
           name: python-package-distributions-macos
           path: ./wheelhouse/*.whl
+      - uses: actions/upload-artifact@v4
+        with:
+          name: python-package-distributions-linux
+          path: ./wheelhouse/*.whl
+
 
   source-distribution:
     name: Build source distribution


### PR DESCRIPTION
Could you please add aarch64 to the list of published archs? We, users of HomeAssistant, found out that mandatory upgrade to 3.12 left us without compiled version, and default image doesn't have gcc to build our own.
https://github.com/DurgNomis-drol/ha_toyota/issues/258


I'm proposing a PR that I partially tested: https://github.com/vermut/marisa-trie/actions/runs/8959884430, but not full version with mac and win. So I'm not sure about double `actions/upload-artifact@v4`

