### PR TITLE
feat: tests on Python 3.14

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
-          cache: pip
       - name: Install test dependencies
         run: python -m pip install ".[test]"
       - name: Test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13-dev"]
+        python: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14-dev"]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14-dev"]
+        python: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14-dev"]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,13 @@
 CHANGES
 =======
 
+1.3.0 (2025-xx-xx)
+------------------
+
+* Dropped Python 3.7 support (#112).
+* Added Python 3.13 support (#112).
+* Rebuild Cython wrapper with Cython 3.0.12.
+
 1.2.1 (2024-10-12)
 ------------------
 

--- a/setup.py
+++ b/setup.py
@@ -47,13 +47,13 @@ CLASSIFIERS = [
     "Programming Language :: Cython",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Programming Language :: Python :: Implementation :: CPython",
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Topic :: Scientific/Engineering :: Information Analysis",
@@ -97,7 +97,7 @@ setup(
             include_dirs=[MARISA_INCLUDE_DIR],
         )
     ],
-    python_requires=">=3.7",
+    python_requires=">=3.8",
     install_requires=install_requires,
     extras_require={
         "test": tests_require,


### PR DESCRIPTION
- Python 3.7 is EOL since [2023-06-27](https://devguide.python.org/versions/#unsupported-versions), and it's no more "easy" to use in the CI. Lets move on.
- Python 3.14-dev is not yet working on Windows:
  ```
  Microsoft (R) Library Manager Version 14.42.34436.0
  Copyright (C) Microsoft Corporation.  All rights reserved.
  
  running build_ext
  building 'marisa_trie' extension
  creating build\temp.win-amd64-cpython-314\Release\src
  "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.42.34433\bin\HostX86\x64\cl.exe" /c /nologo /O2 /W3 /GL /DNDEBUG /MD -Imarisa-trie\include -IC:\hostedtoolcache\windows\Python\3.14.0-alpha.5\x64\include -IC:\hostedtoolcache\windows\Python\3.14.0-alpha.5\x64\Include "-IC:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.42.34433\include" "-IC:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.42.34433\ATLMFC\include" "-IC:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\VS\include" "-IC:\Program Files (x86)\Windows Kits\10\include\10.0.26100.0\ucrt" "-IC:\Program Files (x86)\Windows Kits\10\\include\10.0.26100.0\\um" "-IC:\Program Files (x86)\Windows Kits\10\\include\10.0.26100.0\\shared" "-IC:\Program Files (x86)\Windows Kits\10\\include\10.0.26100.0\\winrt" "-IC:\Program Files (x86)\Windows Kits\10\\include\10.0.26100.0\\cppwinrt" "-IC:\Program Files (x86)\Windows Kits\NETFXSDK\4.8\include\um" /EHsc /Tpsrc/agent.cpp /Fobuild\temp.win-amd64-cpython-314\Release\src\agent.obj
  agent.cpp
  C:\hostedtoolcache\windows\Python\3.14.0-alpha.5\x64\include\internal\pycore_stackref.h(278): error C7555: use of designated initializers requires at least '/std:c++20'
  C:\hostedtoolcache\windows\Python\3.14.0-alpha.5\x64\include\internal\pycore_stackref.h(278): error C2737: 'PyStackRef_NULL': const object must be initialized
  C:\hostedtoolcache\windows\Python\3.14.0-alpha.5\x64\include\internal/pycore_frame.h(195): error C7555: use of designated initializers requires at least '/std:c++20'
  C:\hostedtoolcache\windows\Python\3.14.0-alpha.5\x64\include\internal/pycore_frame.h(195): error C4576: a parenthesized type followed by an initializer list is a non-standard explicit type conversion syntax
  C:\hostedtoolcache\windows\Python\3.14.0-alpha.5\x64\include\internal/pycore_frame.h(370): error C7555: use of designated initializers requires at least '/std:c++20'
  C:\hostedtoolcache\windows\Python\3.14.0-alpha.5\x64\include\internal/pycore_frame.h(370): error C4576: a parenthesized type followed by an initializer list is a non-standard explicit type conversion syntax
  C:\hostedtoolcache\windows\Python\3.14.0-alpha.5\x64\include\internal/pycore_frame.h(371): error C7555: use of designated initializers requires at least '/std:c++20'
  C:\hostedtoolcache\windows\Python\3.14.0-alpha.5\x64\include\internal/pycore_frame.h(371): error C4576: a parenthesized type followed by an initializer list is a non-standard explicit type conversion syntax
  error: command 'C:\\Program Files\\Microsoft Visual Studio\\2022\\Enterprise\\VC\\Tools\\MSVC\\14.42.34433\\bin\\HostX86\\x64\\cl.exe' failed with exit code 2
  ```