### PR TITLE
move setuptools to setup_requires, use importlib.metadata in test

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,9 +13,10 @@ tests_require = [
     "pytest",
     "readme_renderer",
 ]
-install_requires = [
+setup_requires = [
     "setuptools",
 ]
+install_requires = []
 
 MARISA_ROOT_DIR = "marisa-trie"
 MARISA_SOURCE_DIR = os.path.join(MARISA_ROOT_DIR, "lib")
@@ -98,6 +99,7 @@ setup(
         )
     ],
     python_requires=">=3.8",
+    setup_requires=setup_requires,
     install_requires=install_requires,
     extras_require={
         "test": tests_require,

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -4,8 +4,8 @@ Shamelessly inspired from https://github.com/pypa/twine/blob/main/twine/commands
 import io
 import re
 import subprocess
-from email import message_from_string
-from pkg_resources import get_distribution
+
+from importlib.metadata import distribution
 
 from readme_renderer.rst import render
 
@@ -47,10 +47,8 @@ class _WarningStream:
 def test_check_pypi_rendering():
     subprocess.check_call(["python3", "setup.py", "sdist"])
 
-    package = get_distribution("marisa-trie")
-    pkg_info = message_from_string(package.get_metadata("PKG-INFO"))
-    metadata = dict(pkg_info.items())
-    lines = metadata["Summary"].splitlines()
+    package = distribution("marisa-trie")
+    lines = package.metadata.get("Summary").splitlines()
     description = lines.pop(0) + "\n"
     description += "\n".join(l[8:] for l in lines)
 


### PR DESCRIPTION
Hi, thanks for this tool!

This PR moves `setuptools` from a runtime requirement (which it does not appear to use) to a build time requirement.

I guess the recommended approach would be to remove _both_ fields from `setup.py`, and declare a minimal `pyproject.toml`:

```toml
[build-system]
requires = ["setuptools"]
build-backend = "setuptools.build_meta"
```

Update: [05a88f8](https://github.com/pytries/marisa-trie/pull/113/commits/05a88f83594b9485b861bd256d59ae1db1df7b4d) changes the test time use of `pkg_resources.get_distribution` to `importlib.metadata.distribution`, which also handles the email parsing behavior.