### PR TITLE
Update libmarisa-trie to 0.2.7

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ CHANGES
 1.3.0 (2025-xx-xx)
 ------------------
 
+* Updated ``libmarisa-trie`` to the latest version (0.2.7).
 * Dropped Python 3.7 support (#112).
 * Added Python 3.13 support (#112).
 * Rebuild Cython wrapper with Cython 3.0.12.


### PR DESCRIPTION
After 5 years, a new release :confetti_ball: 

-> https://github.com/s-yata/marisa-trie/releases/tag/v0.2.7