### PR TITLE
Move project metadata to pyproject.toml

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - ".github/workflows/build-and-publish.yml"
+      - "pyproject.toml"
       - "setup.*"
 
   workflow_dispatch:
@@ -66,9 +67,8 @@ jobs:
           python-version: "3.12"
       - name: Build source distribution
         run: |
-          # FIXME: setuptools was removed starting with Python 3.12
-          pip install --upgrade --force setuptools
-          python setup.py sdist
+          pip install build
+          python -m build --sdist
       - name: Store the source distribution
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -16,23 +16,30 @@ on:
 
 jobs:
   os-built-distributions:
-    name: Build on ${{ matrix.os }}
+    name: Build ${{ matrix.arch }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        include:
+          - os: ubuntu-latest
+            arch: x86_64
+          - os: ubuntu-24.04-arm
+            arch: aarch64
+          - os: windows-latest
+            arch: AMD64
+          - os: windows-latest
+            arch: x86
+          - os: macos-latest
+            arch: x86_64
+          - os: macos-latest
+            arch: arm64
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.inputs.branch }}
           submodules: true
-
-      - name: Set up QEMU
-        if: runner.os == 'Linux'
-        uses: docker/setup-qemu-action@v3
-        with:
-          platforms: all
 
       - name: Install Python
         uses: actions/setup-python@v5
@@ -43,13 +50,11 @@ jobs:
       - name: Build wheels
         run: python -m cibuildwheel
         env:
-          CIBW_SKIP: "pp*"  # skip PyPy releases
-          CIBW_ARCHS_MACOS: "x86_64 universal2 arm64"
-          CIBW_ARCHS_LINUX: "auto aarch64"
+          CIBW_ARCHS: ${{ matrix.arch }}
           CIBW_ENABLE: cpython-freethreading
       - uses: actions/upload-artifact@v4
         with:
-          name: python-package-distributions-${{ matrix.os }}
+          name: python-package-distributions-${{ matrix.os }}-${{ matrix.arch }}
           path: ./wheelhouse/*.whl
 
   source-distribution:

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -89,4 +89,4 @@ jobs:
         with:
           user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}
-          skip_existing: true
+          skip-existing: true

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -21,19 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - os: ubuntu-latest
-            arch: x86_64
-          - os: ubuntu-24.04-arm
-            arch: aarch64
-          - os: windows-latest
-            arch: AMD64
-          - os: windows-latest
-            arch: x86
-          - os: macos-latest
-            arch: x86_64
-          - os: macos-latest
-            arch: arm64
+        os: [ubuntu-latest, ubuntu-24.04-arm, windows-latest, macos-latest]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -50,7 +38,7 @@ jobs:
       - name: Build wheels
         run: python -m cibuildwheel
         env:
-          CIBW_ARCHS: ${{ matrix.arch }}
+          CIBW_ARCHS_MACOS: "auto x86_64"
           CIBW_ENABLE: cpython-freethreading
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14-dev"]
+        python: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14-dev"]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,7 @@ CHANGES
 * Dropped Python 3.7 support (#112).
 * Added Python 3.13 support (#112).
 * Rebuild Cython wrapper with Cython 3.1.2 (#119).
+* Moved static project metadata to ``pyproject.toml`` (#120).
 
 1.2.1 (2024-10-12)
 ------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,10 +6,11 @@ CHANGES
 ------------------
 
 * Updated ``libmarisa-trie`` to the latest version (0.2.7) (#116).
-* Dropped Python 3.7 support (#112).
+* Dropped Python 3.7, 3.8 support (#112, #120).
 * Added Python 3.13 support (#112).
 * Rebuild Cython wrapper with Cython 3.1.2 (#119).
 * Moved static project metadata to ``pyproject.toml`` (#120).
+* Updated metadata license to include the bundled one from marisa-trie as well (#120).
 
 1.2.1 (2024-10-12)
 ------------------

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,3 @@
-include README.rst
-include CHANGES.rst
-include LICENSE
 include update_cpp.sh
 
 recursive-include src *.cpp *.pxd *.pyx

--- a/README.rst
+++ b/README.rst
@@ -58,7 +58,7 @@ License
 Wrapper code is licensed under MIT License.
 
 Bundled `marisa-trie`_ C++ library is dual-licensed under
-LGPL and BSD 2-clause license.
+LGPL or BSD 2-clause license.
 
 .. |PyPI Version| image:: https://img.shields.io/pypi/v/marisa-trie.svg
    :target: https://pypi.python.org/pypi/marisa-trie/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,14 +1,18 @@
 [build-system]
 build-backend = "setuptools.build_meta"
-requires = ["setuptools>=67.1"]
+requires = ["setuptools>=77.0"]
 
 [project]
 name = "marisa-trie"
 version = "1.2.1"
-license.text = "MIT"
+license = "MIT AND (BSD-2-Clause OR LGPL-2.1-or-later)"
+license-files = [
+  "LICENSE",
+  "marisa-trie/COPYING.md",
+]
 description = "Static memory-efficient and fast Trie-like structures for Python."
 authors = [{ name = "Mikhail Korobov", email = "kmike84@gmail.com" }]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 classifiers = [
   "Development Status :: 4 - Beta",
   "Intended Audience :: Developers",
@@ -16,7 +20,6 @@ classifiers = [
   "Programming Language :: Cython",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,9 @@ name = "marisa-trie"
 version = "1.2.1"
 license = "MIT AND (BSD-2-Clause OR LGPL-2.1-or-later)"
 license-files = [
+  "AUTHORS.rst",
   "LICENSE",
+  "marisa-trie/AUTHORS",
   "marisa-trie/COPYING.md",
 ]
 description = "Static memory-efficient and fast Trie-like structures for Python."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,45 @@
+[build-system]
+build-backend = "setuptools.build_meta"
+requires = ["setuptools>=67.1"]
+
+[project]
+name = "marisa-trie"
+version = "1.2.1"
+license.text = "MIT"
+description = "Static memory-efficient and fast Trie-like structures for Python."
+authors = [{ name = "Mikhail Korobov", email = "kmike84@gmail.com" }]
+requires-python = ">=3.8"
+classifiers = [
+  "Development Status :: 4 - Beta",
+  "Intended Audience :: Developers",
+  "Intended Audience :: Science/Research",
+  "Programming Language :: Cython",
+  "Programming Language :: Python",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.8",
+  "Programming Language :: Python :: 3.9",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
+  "Programming Language :: Python :: Implementation :: CPython",
+  "Topic :: Software Development :: Libraries :: Python Modules",
+  "Topic :: Scientific/Engineering :: Information Analysis",
+  "Topic :: Text Processing :: Linguistic",
+]
+dynamic = ["readme"]
+
+[project.optional-dependencies]
+# Note: keep requirements here to ease distributions packaging
+test = [
+  "hypothesis",
+  "pytest",
+  "readme_renderer",
+]
+
+[project.urls]
+Source = "https://github.com/pytries/marisa-trie"
+
+[tool.setuptools.dynamic]
+readme = { file = ["README.rst", "CHANGES.rst"] }

--- a/setup.py
+++ b/setup.py
@@ -1,21 +1,9 @@
-"""Static memory-efficient and fast Trie-like structures for Python."""
-
 import glob
 import itertools
 import os.path
 
 from setuptools import setup, Extension
 
-
-# Note: keep requirements here to ease distributions packaging
-tests_require = [
-    "hypothesis",
-    "pytest",
-    "readme_renderer",
-]
-install_requires = [
-    "setuptools",
-]
 
 MARISA_ROOT_DIR = "marisa-trie"
 MARISA_SOURCE_DIR = os.path.join(MARISA_ROOT_DIR, "lib")
@@ -32,45 +20,8 @@ MARISA_FILES[:] = itertools.chain(
     *(glob.glob(os.path.join(MARISA_SOURCE_DIR, path)) for path in MARISA_FILES)
 )
 
-DESCRIPTION = __doc__
-with open("README.rst", encoding="utf-8") as f1, open(
-    "CHANGES.rst", encoding="utf-8"
-) as f2:
-    LONG_DESCRIPTION = f1.read() + f2.read()
-LICENSE = "MIT"
-
-CLASSIFIERS = [
-    "Development Status :: 4 - Beta",
-    "Intended Audience :: Developers",
-    "Intended Audience :: Science/Research",
-    "License :: OSI Approved :: MIT License",
-    "Programming Language :: Cython",
-    "Programming Language :: Python",
-    "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
-    "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.11",
-    "Programming Language :: Python :: 3.12",
-    "Programming Language :: Python :: 3.13",
-    "Programming Language :: Python :: 3.14",
-    "Programming Language :: Python :: Implementation :: CPython",
-    "Topic :: Software Development :: Libraries :: Python Modules",
-    "Topic :: Scientific/Engineering :: Information Analysis",
-    "Topic :: Text Processing :: Linguistic",
-]
 
 setup(
-    name="marisa-trie",
-    version="1.2.1",
-    description=DESCRIPTION,
-    long_description=LONG_DESCRIPTION,
-    long_description_content_type="text/x-rst",
-    author="Mikhail Korobov",
-    author_email="kmike84@gmail.com",
-    license=LICENSE,
-    url="https://github.com/pytries/marisa-trie",
-    classifiers=CLASSIFIERS,
     libraries=[
         (
             "libmarisa-trie",
@@ -97,9 +48,4 @@ setup(
             include_dirs=[MARISA_INCLUDE_DIR],
         )
     ],
-    python_requires=">=3.8",
-    install_requires=install_requires,
-    extras_require={
-        "test": tests_require,
-    },
 )

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -3,9 +3,7 @@ Shamelessly inspired from https://github.com/pypa/twine/blob/main/twine/commands
 """
 import io
 import re
-import subprocess
-from email import message_from_string
-from pkg_resources import get_distribution
+from importlib.metadata import metadata
 
 from readme_renderer.rst import render
 
@@ -45,12 +43,7 @@ class _WarningStream:
 
 
 def test_check_pypi_rendering():
-    subprocess.check_call(["python3", "setup.py", "sdist"])
-
-    package = get_distribution("marisa-trie")
-    pkg_info = message_from_string(package.get_metadata("PKG-INFO"))
-    metadata = dict(pkg_info.items())
-    lines = metadata["Summary"].splitlines()
+    lines = metadata("marisa-trie").get("Summary", "").splitlines()
     description = lines.pop(0) + "\n"
     description += "\n".join(l[8:] for l in lines)
 


### PR DESCRIPTION
Followup to https://github.com/pytries/marisa-trie/pull/113#issuecomment-2888339866

This PR moves the static project metadata from `setup.py` to `pyproject.toml`. It also removes `setuptools` as a required dependency, it's only necessary as part of the build system. Furthermore, I've removed the license classifier in preparation for [PEP 639](https://peps.python.org/pep-0639/). This is supported by setuptools `>=77.0`, however it's only available for Python 3.9+. So this has to wait until 3.8 is dropped.


Metadata diff
```diff
 ...
-Author: Mikhail Korobov
-Author-email: kmike84@gmail.com
+Author-email: Mikhail Korobov <kmike84@gmail.com>
-Home-page: https://github.com/pytries/marisa-trie
+Project-URL: Source, https://github.com/pytries/marisa-trie
 License: MIT
 ...
-Classifier: License :: OSI Approved :: MIT License
 ...
-Requires-Dist: setuptools
 ...
```