### PR TITLE
Set cythonize language_level="3"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,5 +40,5 @@ setup(
             },
         )
     ],
-    ext_modules=cythonize(extensions),
+    ext_modules=cythonize(extensions, language_level="3"),
 )


### PR DESCRIPTION
```python
/usr/lib/python3/dist-packages/Cython/Compiler/Main.py:381: FutureWarning: Cython directive 'language_level' not set, using '3str' for now (Py3). This has changed from earlier releases! File: /home/ut005408/work/2025-08/python-marisa-trie/src/marisa_trie.pyx
src/marisa_trie.pyx:524:39: str objects do not support coercion to unicode, use a unicode string literal instead (u'')
```

<details><summary>Relevant build log</summary>

```python
   dh_auto_build -O--buildsystem=pybuild
I: pybuild plugin_pyproject:129: Building wheel for python3.13 with "build" module
I: pybuild base:311: python3.13 -m build --skip-dependency-check --no-isolation --wheel --outdir /home/ut005408/work/2025-08/python-marisa-trie/.pybuild/cpython3_3.13_marisa-trie  
* Building wheel...
Compiling src/marisa_trie.pyx because it changed.
[1/1] Cythonizing src/marisa_trie.pyx
/usr/lib/python3/dist-packages/Cython/Compiler/Main.py:381: FutureWarning: Cython directive 'language_level' not set, using '3str' for now (Py3). This has changed from earlier releases! File: /home/ut005408/work/2025-08/python-marisa-trie/src/marisa_trie.pyx
  tree = Parsing.p_module(s, pxd, full_module_name)
warning: src/marisa_trie.pyx:235:10: Only extern functions can throw C++ exceptions.
warning: src/marisa_trie.pyx:242:10: Only extern functions can throw C++ exceptions.

Error compiling Cython file:
------------------------------------------------------------
...
        ag.set_query(b_key, len(b_key))

        while self._trie.common_prefix_search(ag):
            yield (self._get_key(ag), ag.key().id())

    def iteritems(self, unicode prefix=""):
                                       ^
------------------------------------------------------------

src/marisa_trie.pyx:524:39: str objects do not support coercion to unicode, use a unicode string literal instead (u'')

Error compiling Cython file:
------------------------------------------------------------
...
        ag.set_query(b_prefix)

        while self._trie.predictive_search(ag):
            yield self._get_key(ag), ag.key().id()

    def items(self, unicode prefix=""):
                                   ^
------------------------------------------------------------

src/marisa_trie.pyx:535:35: str objects do not support coercion to unicode, use a unicode string literal instead (u'')

Error compiling Cython file:
------------------------------------------------------------
...
            value = ag.key().ptr()[prefix_len:ag.key().length()]
            res.append(value)

        return res

    cpdef list items(self, unicode prefix=""):
                                          ^
------------------------------------------------------------

src/marisa_trie.pyx:659:42: str objects do not support coercion to unicode, use a unicode string literal instead (u'')

Error compiling Cython file:
------------------------------------------------------------
...
            res.append(
                (key, value)
            )
        return res

    def iteritems(self, unicode prefix=""):
                                       ^
------------------------------------------------------------

src/marisa_trie.pyx:686:39: str objects do not support coercion to unicode, use a unicode string literal instead (u'')

Error compiling Cython file:
------------------------------------------------------------
...
                    key = raw_key[:i].decode('utf8')
                    res.append(key)
                    break
        return res

    def iterkeys(self, unicode prefix=""):
                                      ^
------------------------------------------------------------

src/marisa_trie.pyx:729:38: str objects do not support coercion to unicode, use a unicode string literal instead (u'')

Error compiling Cython file:
------------------------------------------------------------
...

    cpdef list b_get_value(self, bytes key):
        cdef list values = BytesTrie.b_get_value(self, key)
        return [self._unpack(val) for val in values]

    cpdef list items(self, unicode prefix=""):
                                          ^
------------------------------------------------------------

src/marisa_trie.pyx:763:42: str objects do not support coercion to unicode, use a unicode string literal instead (u'')

Error compiling Cython file:
------------------------------------------------------------
...

    cpdef list items(self, unicode prefix=""):
        cdef list items = BytesTrie.items(self, prefix)
        return [(key, self._unpack(val)) for (key, val) in items]

    def iteritems(self, unicode prefix=""):
                                       ^
------------------------------------------------------------

src/marisa_trie.pyx:767:39: str objects do not support coercion to unicode, use a unicode string literal instead (u'')
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/pyproject_hooks/_in_process/_in_process.py", line 389, in <module>
    main()
    ~~~~^^
  File "/usr/lib/python3/dist-packages/pyproject_hooks/_in_process/_in_process.py", line 373, in main
    json_out["return_val"] = hook(**hook_input["kwargs"])
                             ~~~~^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/pyproject_hooks/_in_process/_in_process.py", line 280, in build_wheel
    return _build_backend().build_wheel(
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
        wheel_directory, config_settings, metadata_directory
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/usr/lib/python3/dist-packages/setuptools/build_meta.py", line 435, in build_wheel
    return _build(['bdist_wheel'])
  File "/usr/lib/python3/dist-packages/setuptools/build_meta.py", line 426, in _build
    return self._build_with_temp_dir(
           ~~~~~~~~~~~~~~~~~~~~~~~~~^
        cmd,
        ^^^^
    ...<3 lines>...
        self._arbitrary_args(config_settings),
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/usr/lib/python3/dist-packages/setuptools/build_meta.py", line 407, in _build_with_temp_dir
    self.run_setup()
    ~~~~~~~~~~~~~~^^
  File "/usr/lib/python3/dist-packages/setuptools/build_meta.py", line 320, in run_setup
    exec(code, locals())
    ~~~~^^^^^^^^^^^^^^^^
  File "<string>", line 18, in <module>
  File "/usr/lib/python3/dist-packages/Cython/Build/Dependencies.py", line 1154, in cythonize
    cythonize_one(*args)
    ~~~~~~~~~~~~~^^^^^^^
  File "/usr/lib/python3/dist-packages/Cython/Build/Dependencies.py", line 1321, in cythonize_one
    raise CompileError(None, pyx_file)
Cython.Compiler.Errors.CompileError: src/marisa_trie.pyx

ERROR Backend subprocess exited when trying to invoke build_wheel
E: pybuild pybuild:389: build: plugin pyproject failed with: exit code=1: python3.13 -m build --skip-dependency-check --no-isolation --wheel --outdir /home/ut005408/work/2025-08/python-marisa-trie/.pybuild/cpython3_3.13_marisa-trie  
dh_auto_build: error: pybuild --build -i python{version} -p 3.13 returned exit code 13
make: *** [debian/rules:7: binary] Error 13
dpkg-buildpackage: error: debian/rules binary subprocess returned exit status 2
```

</details> 