### PR TITLE
Free-threading: test sharing objects between threads

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
   "Programming Language :: Python :: 3.14",
-  "Programming Language :: Python :: Free Threading :: 1 - Alpha",
+  "Programming Language :: Python :: Free Threading :: 2 - Beta",
   "Programming Language :: Python :: Implementation :: CPython",
   "Topic :: Software Development :: Libraries :: Python Modules",
   "Topic :: Scientific/Engineering :: Information Analysis",
@@ -52,3 +52,9 @@ Source = "https://github.com/pytries/marisa-trie"
 
 [tool.setuptools.dynamic]
 readme = { file = ["README.rst", "CHANGES.rst"] }
+
+[tool.pytest.ini_options]
+markers = [
+  # Add pytest-run-parallel markers when the module is not installed
+  "thread_unsafe: Run in a single thread in pytest-run-parallel",
+]

--- a/tests/test_binary_trie.py
+++ b/tests/test_binary_trie.py
@@ -1,4 +1,5 @@
 import pickle
+from collections.abc import Mapping
 from uuid import uuid4
 
 import pytest
@@ -6,8 +7,6 @@ import hypothesis.strategies as st
 from hypothesis import given, assume, settings, HealthCheck
 
 import marisa_trie
-
-from .utils import Mapping
 
 text = st.binary()
 
@@ -258,6 +257,6 @@ def test_invalid_file():
         pytest.fail("Exception is not raised")
 
 
-def test_mutable_mapping():
+def test_mapping():
     for method in Mapping.__abstractmethods__:
         assert hasattr(marisa_trie.BinaryTrie, method)

--- a/tests/test_bytes_trie.py
+++ b/tests/test_bytes_trie.py
@@ -1,5 +1,6 @@
 import io
 import pickle
+from collections.abc import Mapping
 
 import pytest
 import hypothesis.strategies as st
@@ -125,3 +126,8 @@ def test_dumps_loads(data):
     buf.seek(0)
 
     assert trie == pickle.load(buf)
+
+
+def test_mapping():
+    for method in Mapping.__abstractmethods__:
+        assert hasattr(marisa_trie.BytesTrie, method)

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -1,9 +1,12 @@
 """
 Shamelessly inspired from https://github.com/pypa/twine/blob/main/twine/commands/check.py
 """
+
 import io
 import re
 from importlib.metadata import metadata
+
+import pytest
 
 from readme_renderer.rst import render
 
@@ -42,6 +45,7 @@ class _WarningStream:
         return self.output.getvalue()
 
 
+@pytest.mark.thread_unsafe(reason="Spurious importlib warnings")
 def test_check_pypi_rendering():
     lines = metadata("marisa-trie").get("Summary", "").splitlines()
     description = lines.pop(0) + "\n"

--- a/tests/test_record_trie.py
+++ b/tests/test_record_trie.py
@@ -6,9 +6,7 @@ from hypothesis import given
 
 import marisa_trie
 
-from .utils import text
-
-records = st.tuples(st.integers(min_value=0, max_value=2 ** 16 - 1), st.booleans())
+from .utils import text, records
 
 
 @given(st.sets(st.tuples(text, records)))

--- a/tests/test_threading.py
+++ b/tests/test_threading.py
@@ -1,0 +1,173 @@
+"""Tests for sharing the same object across threads.
+Note that all other modules of this test suite run under pytest-run-parallel,
+which tests that different objects can be created and consumed in parallel threads.
+"""
+from __future__ import annotations
+
+import pickle
+from functools import partial
+from uuid import uuid4
+
+import pytest
+import hypothesis.strategies as st
+from hypothesis import given, settings, HealthCheck
+
+import marisa_trie
+
+from .utils import text, records, run_threaded
+
+pytestmark = [pytest.mark.thread_unsafe(reason="Test itself spawns threads")]
+
+
+def parametrize(min_size: int = 0, max_size: int | None = None) -> pytest.MarkDecorator:
+    return pytest.mark.parametrize(
+        "cls,data_st",
+        [
+            pytest.param(
+                marisa_trie.Trie,
+                st.sets(text, min_size=min_size, max_size=max_size),
+                id="Trie",
+            ),
+            pytest.param(
+                marisa_trie.BinaryTrie,
+                st.sets(st.binary(), min_size=min_size, max_size=max_size),
+                id="BinaryTrie",
+            ),
+            pytest.param(
+                marisa_trie.BytesTrie,
+                st.dictionaries(
+                    text, st.binary(), min_size=min_size, max_size=max_size
+                ),
+                id="BytesTrie",
+            ),
+            pytest.param(
+                partial(marisa_trie.RecordTrie, "<H?"),
+                st.dictionaries(text, records, min_size=min_size, max_size=max_size),
+                id="RecordTrie",
+            ),
+        ],
+    )
+
+
+def make_trie(cls, data_st, data):
+    contents = data.draw(data_st)
+    if isinstance(contents, dict):
+        trie = cls(contents.items())
+        as_dict = {k: [v] for k, v in contents.items()}
+    else:  # set of keys
+        trie = cls(contents)
+        as_dict = dict(trie)
+        assert as_dict.keys() == contents
+    return trie, as_dict
+
+
+@parametrize(8, 8)  # Must be >= max_workers
+@given(st.data())
+def test_get_different_keys(cls, data_st, data):
+    """Call __contains__, __getitem__, get, restore_key
+    where multiple threads access different keys on the same container.
+    """
+    trie, as_dict = make_trie(cls, data_st, data)
+
+    def f(i):
+        key = list(as_dict)[i]
+        value = as_dict[key]
+
+        assert key in trie  # __contains__
+        assert trie[key] == value  # __getitem__
+        assert trie.get(key) == value
+        if hasattr(trie, "restore_key"):
+            assert trie.restore_key(value) == key
+
+    run_threaded(f, pass_count=True, max_workers=8)
+
+
+@parametrize(3, 3)
+@given(st.data())
+def test_get_same_key(cls, data_st, data):
+    """Call __contains__, __getitem__, get, restore_key
+    where multiple threads access the same key on the same container.
+    """
+    trie, as_dict = make_trie(cls, data_st, data)
+    key = data.draw(st.sampled_from(list(as_dict)))
+    value = as_dict[key]
+
+    def f():
+        assert key in trie  # __contains__
+        assert trie[key] == value  # __getitem__
+        assert trie.get(key) == value
+        if hasattr(trie, "restore_key"):
+            assert trie.restore_key(value) == key
+
+    run_threaded(f)
+
+
+@parametrize()
+@given(st.data())
+def test_iter(cls, data_st, data):
+    """Different threads call __iter__, keys, iterkeys, items, iteritems
+    on the same object
+    """
+    trie, as_dict = make_trie(cls, data_st, data)
+
+    def f():
+        keys = list(trie)  # __iter__
+        assert list(trie.keys()) == keys
+        assert list(trie.iterkeys()) == keys
+        assert set(keys) == set(as_dict)
+
+        items = list(trie.items())
+        assert list(trie.iteritems()) == items
+        assert [k for k, _ in items] == keys
+        assert dict(items) == {
+            k: v[0] if isinstance(v, list) else v for k, v in as_dict.items()
+        }
+
+    run_threaded(f)
+
+
+@parametrize()
+@settings(suppress_health_check=[HealthCheck.function_scoped_fixture])
+@given(st.data())
+def test_saveload(tmp_path, cls, data_st, data):
+    """Different threads call save() on the same object, to write different files."""
+    trie, as_dict = make_trie(cls, data_st, data)
+
+    def f():
+        path = str(tmp_path / f"{uuid4()}.bin")
+        trie.save(path)
+        trie2 = cls().load(path)
+        assert trie2 == trie
+        assert dict(trie2) == as_dict
+
+    run_threaded(f)
+
+
+@parametrize()
+@given(st.data())
+def test_tobytes_frombytes(cls, data_st, data):
+    """Different threads call tobytes() on the same object"""
+    trie, as_dict = make_trie(cls, data_st, data)
+
+    def f():
+        bin = trie.tobytes()
+        trie2 = cls().frombytes(bin)
+        assert trie2 == trie
+        assert dict(trie2) == as_dict
+
+    run_threaded(f)
+
+
+@parametrize()
+@given(st.data())
+def test_dumps_loads(cls, data_st, data):
+    """Different threads call pickle.dumps() on the same object"""
+    trie, as_dict = make_trie(cls, data_st, data)
+
+    def f():
+        pik = pickle.dumps(trie)
+        trie2 = pickle.loads(pik)
+        assert trie2 == trie
+        assert dict(trie2) == as_dict
+
+    run_threaded(f)

--- a/tests/test_trie.py
+++ b/tests/test_trie.py
@@ -1,4 +1,5 @@
 import pickle
+from collections.abc import Mapping
 from uuid import uuid4
 
 import pytest
@@ -7,7 +8,7 @@ from hypothesis import given, assume, settings, HealthCheck
 
 import marisa_trie
 
-from .utils import text, Mapping
+from .utils import text
 
 
 @given(st.sets(text), text)
@@ -227,6 +228,7 @@ def test_prefixes():
 
     assert list(trie.iter_prefixes("foobar")) == ["f", "foo", "foobar"]
 
+
 def test_iter_prefixes_with_keys():
     trie = marisa_trie.Trie(["foo", "f", "foobar", "bar"])
 
@@ -246,6 +248,7 @@ def test_iter_prefixes_with_keys():
         assert list(trie.iter_prefixes_with_ids(test_key)) == [
             (prefix, trie[prefix]) for prefix in trie.prefixes(test_key)
         ]
+
 
 def test_keys():
     keys = ["foo", "f", "foobar", "bar"]
@@ -328,6 +331,6 @@ def test_invalid_file():
         pytest.fail("Exception is not raised")
 
 
-def test_mutable_mapping():
+def test_mapping():
     for method in Mapping.__abstractmethods__:
         assert hasattr(marisa_trie.Trie, method)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,8 +1,57 @@
+import concurrent.futures
+import threading
 import string
-from collections.abc import Mapping
 
+import pytest
 import hypothesis.strategies as st
 
-text = st.text(f"абвгдеёжзиклмнопрстуфхцчъыьэюя{string.ascii_lowercase}")
 
-__all__ = ("Mapping", text)
+__all__ = ("text", "records", "run_threaded")
+
+
+text = st.text(f"абвгдеёжзиклмнопрстуфхцчъыьэюя{string.ascii_lowercase}")
+records = st.tuples(st.integers(min_value=0, max_value=2**16 - 1), st.booleans())
+
+
+def run_threaded(
+    func,
+    max_workers=8,
+    pass_count=False,
+    pass_barrier=False,
+    outer_iterations=1,
+    prepare_args=None,
+):
+    """Runs a function many times in parallel.
+
+    Copied from https://github.com/numpy/numpy/blob/main/numpy/testing/_private/utils.py
+    Copyright (c) 2005-2025, NumPy Developers. All rights reserved.
+    Full license: https://github.com/numpy/numpy/blob/main/LICENSE.txt
+    """
+    for _ in range(outer_iterations):
+        with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as tpe:
+            if prepare_args is None:
+                args = []
+            else:
+                args = prepare_args()
+            if pass_barrier:
+                barrier = threading.Barrier(max_workers)
+                args.append(barrier)
+            if pass_count:
+                all_args = [(func, i, *args) for i in range(max_workers)]
+            else:
+                all_args = [(func, *args) for i in range(max_workers)]
+            try:
+                futures = []
+                for arg in all_args:
+                    futures.append(tpe.submit(*arg))
+            except RuntimeError as e:
+                pytest.skip(
+                    f"Spawning {max_workers} threads failed with "
+                    f"error {e!r} (likely due to resource limits on the "
+                    "system running the tests)"
+                )
+            finally:
+                if len(futures) < max_workers and pass_barrier:
+                    barrier.abort()
+            for f in futures:
+                f.result()


### PR DESCRIPTION
Follow-up to #128
Add tests that share *Trie instances between threads (e.g. two threads call methods of the same object in parallel).

Bump up the free-threading support marker to 2 - Beta.
I would advise to get some real-life feedback from production before bumping it to 3 - Stable.