### PR TITLE
Add support for building marisa-trie python library on Windows ARM64

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, ubuntu-24.04-arm, windows-latest, macos-latest]
+        os: [ubuntu-latest, ubuntu-24.04-arm, windows-latest, windows-11-arm, macos-latest]
     steps:
       - name: Checkout
         uses: actions/checkout@v6


### PR DESCRIPTION
**PR Description: **
- The PR adds support for building and testing marisa-trie on Windows ARM64

**Changes Proposed: **
- Added Windows ARM64 build runner to the workflow