### PR TITLE
fix: update marisa-trie submodule and fix tests

### DIFF
--- a/tests/test_binary_trie.py
+++ b/tests/test_binary_trie.py
@@ -252,7 +252,7 @@ def test_invalid_file():
     try:
         marisa_trie.BinaryTrie().load(__file__)
     except RuntimeError as e:
-        assert "MARISA_FORMAT_ERROR" in e.args[0]
+        assert "std::runtime_error" in e.args[0]
     else:
         pytest.fail("Exception is not raised")
 

--- a/tests/test_trie.py
+++ b/tests/test_trie.py
@@ -326,7 +326,7 @@ def test_invalid_file():
     try:
         marisa_trie.Trie().load(__file__)
     except RuntimeError as e:
-        assert "MARISA_FORMAT_ERROR" in e.args[0]
+        assert "std::runtime_error" in e.args[0]
     else:
         pytest.fail("Exception is not raised")
 


### PR DESCRIPTION
Update marisa-trie submodule to 7be0b30

marisa-trie has switched to standard library exceptions instead of Marisa exceptions like MARISA_FORMAT_ERROR. Fix tests accordingly.

Ref: https://github.com/s-yata/marisa-trie/issues/99
Closes: #132